### PR TITLE
fix: centralize connection management to prevent "too many clients" e…

### DIFF
--- a/lib/rails_lens/connection.rb
+++ b/lib/rails_lens/connection.rb
@@ -3,12 +3,12 @@
 module RailsLens
   class Connection
     class << self
-      def adapter_for(model_class)
-        connection = model_class.connection
-        adapter_name = detect_adapter_name(connection)
+      def adapter_for(model_class, connection = nil)
+        conn = connection || model_class.connection
+        adapter_name = detect_adapter_name(conn)
 
         adapter_class = resolve_adapter_class(adapter_name)
-        adapter_class.new(connection, model_class.table_name)
+        adapter_class.new(conn, model_class.table_name)
       end
 
       def resolve_adapter_class(adapter_name)

--- a/lib/rails_lens/providers/base.rb
+++ b/lib/rails_lens/providers/base.rb
@@ -21,7 +21,7 @@ module RailsLens
       # For :schema type - returns a string with the schema content
       # For :section type - returns a hash with { title: String, content: String } or nil
       # For :notes type - returns an array of note strings
-      def process(model_class)
+      def process(model_class, connection = nil)
         raise NotImplementedError, "#{self.class} must implement #process"
       end
 

--- a/lib/rails_lens/providers/extension_notes_provider.rb
+++ b/lib/rails_lens/providers/extension_notes_provider.rb
@@ -12,7 +12,7 @@ module RailsLens
         RailsLens.config.extensions[:enabled] && model_has_table?(model_class) && !ModelDetector.view_exists?(model_class)
       end
 
-      def process(model_class)
+      def process(model_class, connection = nil)
         results = ExtensionLoader.apply_extensions(model_class)
         results[:notes]
       end

--- a/lib/rails_lens/providers/extensions_provider.rb
+++ b/lib/rails_lens/providers/extensions_provider.rb
@@ -7,7 +7,7 @@ module RailsLens
         :section
       end
 
-      def process(model_class)
+      def process(model_class, connection = nil)
         results = ExtensionLoader.apply_extensions(model_class)
 
         return nil if results[:annotations].empty?

--- a/lib/rails_lens/providers/index_notes_provider.rb
+++ b/lib/rails_lens/providers/index_notes_provider.rb
@@ -12,7 +12,7 @@ module RailsLens
         model_has_table?(model_class) && !ModelDetector.view_exists?(model_class)
       end
 
-      def process(model_class)
+      def process(model_class, connection = nil)
         analyzer = Analyzers::IndexAnalyzer.new(model_class)
         analyzer.analyze
       end

--- a/lib/rails_lens/providers/inheritance_provider.rb
+++ b/lib/rails_lens/providers/inheritance_provider.rb
@@ -7,7 +7,7 @@ module RailsLens
         :section
       end
 
-      def process(model_class)
+      def process(model_class, connection = nil)
         analyzer = Analyzers::Inheritance.new(model_class)
         content = analyzer.analyze
 

--- a/lib/rails_lens/providers/notes_provider_base.rb
+++ b/lib/rails_lens/providers/notes_provider_base.rb
@@ -17,7 +17,7 @@ module RailsLens
         raise NotImplementedError, "#{self.class} must implement #analyzer_class"
       end
 
-      def process(model_class)
+      def process(model_class, connection = nil)
         analyzer = analyzer_class.new(model_class)
         analyzer.analyze
       end

--- a/lib/rails_lens/providers/section_provider_base.rb
+++ b/lib/rails_lens/providers/section_provider_base.rb
@@ -12,7 +12,7 @@ module RailsLens
         raise NotImplementedError, "#{self.class} must implement #analyzer_class"
       end
 
-      def process(model_class)
+      def process(model_class, connection = nil)
         analyzer = analyzer_class.new(model_class)
         content = analyzer.analyze
 

--- a/lib/rails_lens/providers/view_provider.rb
+++ b/lib/rails_lens/providers/view_provider.rb
@@ -8,7 +8,7 @@ module RailsLens
         ModelDetector.view_exists?(model_class)
       end
 
-      def process(model_class)
+      def process(model_class, connection = nil)
         view_metadata = ViewMetadata.new(model_class)
 
         return nil unless view_metadata.view_exists?

--- a/test/rails_lens/connection_pooling_test.rb
+++ b/test/rails_lens/connection_pooling_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module RailsLens
+  class ConnectionPoolingTest < Minitest::Test
+    def setup
+      @pipeline = AnnotationPipeline.new
+      @model_class = Class.new(ApplicationRecord) do
+        self.table_name = 'users'
+
+        def self.name
+          'TestUser'
+        end
+      end
+    end
+
+    def test_uses_single_connection_for_all_providers
+      # Create a custom provider that captures the connection object_id
+      test_provider = Class.new(Providers::Base) do
+        def type
+          :notes
+        end
+
+        def process(model_class, connection = nil)
+          Thread.current[:test_connection_ids] ||= []
+          Thread.current[:test_connection_ids] << connection.object_id if connection
+          []
+        end
+      end
+
+      # Clear default providers and add our test provider multiple times
+      @pipeline.clear
+      5.times { @pipeline.register(test_provider.new) }
+
+      # Process the model
+      Thread.current[:test_connection_ids] = []
+      @pipeline.process(@model_class)
+
+      # All providers should have received the same connection object
+      connection_ids = Thread.current[:test_connection_ids]
+
+      assert_equal 5, connection_ids.length, 'Should have captured 5 connection IDs'
+      assert_equal 1, connection_ids.uniq.length, 'All providers should receive the same connection object'
+    ensure
+      Thread.current[:test_connection_ids] = nil
+    end
+
+    def test_connection_released_after_processing
+      # This test verifies that connections are properly released back to the pool
+      initial_connections = ActiveRecord::Base.connection_pool.connections.size
+
+      # Process multiple models
+      3.times do
+        @pipeline.process(@model_class)
+      end
+
+      # Force a garbage collection to ensure any leaked connections would be visible
+      GC.start
+
+      # Connection pool size should not have grown
+      final_connections = ActiveRecord::Base.connection_pool.connections.size
+
+      assert_equal initial_connections, final_connections,
+                   'Connection pool should not grow after processing'
+    end
+  end
+end


### PR DESCRIPTION
…rrors

- Wrap provider processing in connection_pool.with_connection to ensure single connection per model
- Update all providers to accept optional connection parameter
- Consolidate multiple view metadata queries into single CTE queries for all adapters
- Add connection pooling test to verify proper connection management

This prevents connection exhaustion when annotating large projects by ensuring all providers share a single managed connection throughout the annotation process.