### PR TITLE
fix: improve logger configuration and use ActiveRecord ignore_tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ Gemfile.lock
 /test/dummy/db/*.sqlite3-*
 /test/dummy/log/*.log
 /test/dummy/tmp/
-/test/dummy/doc/erd/
+/test/dummy/doc/

--- a/lib/rails_lens.rb
+++ b/lib/rails_lens.rb
@@ -26,93 +26,11 @@ loader.setup
 
 require_relative 'rails_lens/errors'
 require_relative 'rails_lens/cli'
+require_relative 'rails_lens/configuration'
 
 module RailsLens
   include ActiveSupport::Configurable
-
-  # Add configuration for error handling
-  config_accessor :verbose, default: false
-  config_accessor :debug, default: false
-  config_accessor :raise_on_error, default: false
-
-  # Logger configuration
-  config_accessor :logger
-
-  # Configuration using ActiveSupport::Configurable
-  config_accessor :annotations do
-    {
-      position: :before,
-      format: :rdoc
-    }
-  end
-
-  config_accessor :erd do
-    {
-      output_dir: 'doc/erd',
-      orientation: 'TB',
-      theme: true,
-      default_colors: %w[
-        lightblue
-        lightcoral
-        lightgreen
-        lightyellow
-        plum
-        lightcyan
-        lightgray
-      ]
-    }
-  end
-
-  config_accessor :schema do
-    {
-      adapter: :auto,
-      include_notes: true,
-      exclude_tables: nil, # Will use ActiveRecord::SchemaDumper.ignore_tables if nil
-      format_options: {
-        show_defaults: true,
-        show_comments: true,
-        show_foreign_keys: true,
-        show_indexes: true,
-        show_check_constraints: true
-      }
-    }
-  end
-
-  config_accessor :extensions do
-    {
-      enabled: true,
-      autoload: true,
-      interface_version: '1.0',
-      ignore: [],
-      custom_paths: [],
-      error_reporting: :warn,    # :silent, :warn, :verbose
-      fail_safe_mode: true,      # Continue processing if extensions fail
-      track_health: false        # Track extension success/failure rates
-    }
-  end
-
-  config_accessor :routes do
-    {
-      enabled: true,
-      include_defaults: true,
-      include_constraints: true,
-      pattern: '**/*_controller.rb',
-      exclusion_pattern: 'vendor/**/*_controller.rb'
-    }
-  end
-
-  config_accessor :mailers do
-    {
-      enabled: true,
-      include_templates: true,
-      include_delivery_methods: true,
-      include_variables: true,
-      include_locales: true,
-      include_defaults: true,
-      pattern: '**/*_mailer.rb',
-      exclusion_pattern: 'vendor/**/*_mailer.rb'
-    }
-  end
+  include Configuration
 
   class << self
     def logger

--- a/lib/rails_lens/analyzers/association_analyzer.rb
+++ b/lib/rails_lens/analyzers/association_analyzer.rb
@@ -69,10 +69,10 @@ module RailsLens
           end
         end
       rescue NameError => e
-        Rails.logger.debug { "Failed to check bidirectional association: #{e.message}" }
+        RailsLens.logger.debug { "Failed to check bidirectional association: #{e.message}" }
         false
       rescue NoMethodError => e
-        Rails.logger.debug { "Method error checking bidirectional association: #{e.message}" }
+        RailsLens.logger.debug { "Method error checking bidirectional association: #{e.message}" }
         false
       end
 

--- a/lib/rails_lens/analyzers/composite_keys.rb
+++ b/lib/rails_lens/analyzers/composite_keys.rb
@@ -21,10 +21,10 @@ module RailsLens
 
         nil
       rescue NoMethodError => e
-        Rails.logger.debug { "Failed to analyze composite keys for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Failed to analyze composite keys for #{model_class.name}: #{e.message}" }
         nil
       rescue ActiveRecord::ConnectionNotEstablished => e
-        Rails.logger.debug { "No database connection for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "No database connection for #{model_class.name}: #{e.message}" }
         nil
       end
 
@@ -51,10 +51,10 @@ module RailsLens
         keys = result.pluck('attname')
         keys.empty? ? nil : keys
       rescue ActiveRecord::StatementInvalid => e
-        Rails.logger.debug { "Failed to detect composite keys from database for #{table_name}: #{e.message}" }
+        RailsLens.logger.debug { "Failed to detect composite keys from database for #{table_name}: #{e.message}" }
         nil
       rescue PG::Error => e
-        Rails.logger.debug { "PostgreSQL error detecting composite keys: #{e.message}" }
+        RailsLens.logger.debug { "PostgreSQL error detecting composite keys: #{e.message}" }
         nil
       end
     end

--- a/lib/rails_lens/analyzers/database_constraints.rb
+++ b/lib/rails_lens/analyzers/database_constraints.rb
@@ -24,10 +24,10 @@ module RailsLens
 
         constraints.empty? ? nil : constraints.join("\n")
       rescue ActiveRecord::StatementInvalid => e
-        Rails.logger.debug { "Failed to fetch check constraints for #{table_name}: #{e.message}" }
+        RailsLens.logger.debug { "Failed to fetch check constraints for #{table_name}: #{e.message}" }
         nil
       rescue NoMethodError => e
-        Rails.logger.debug { "Check constraints not supported by adapter: #{e.message}" }
+        RailsLens.logger.debug { "Check constraints not supported by adapter: #{e.message}" }
         nil
       end
     end

--- a/lib/rails_lens/analyzers/delegated_types.rb
+++ b/lib/rails_lens/analyzers/delegated_types.rb
@@ -81,10 +81,10 @@ module RailsLens
 
         delegated_info
       rescue NoMethodError => e
-        Rails.logger.debug { "Failed to find delegated type info for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Failed to find delegated type info for #{model_class.name}: #{e.message}" }
         nil
       rescue ActiveRecord::StatementInvalid => e
-        Rails.logger.debug { "Database error finding delegated type info: #{e.message}" }
+        RailsLens.logger.debug { "Database error finding delegated type info: #{e.message}" }
         nil
       end
 
@@ -118,10 +118,10 @@ module RailsLens
           []
         end
       rescue ActiveRecord::StatementInvalid => e
-        Rails.logger.debug { "Database error inferring delegated types: #{e.message}" }
+        RailsLens.logger.debug { "Database error inferring delegated types: #{e.message}" }
         []
       rescue Errno::ENOENT => e
-        Rails.logger.debug { "File not found when inferring delegated types: #{e.message}" }
+        RailsLens.logger.debug { "File not found when inferring delegated types: #{e.message}" }
         []
       end
     end

--- a/lib/rails_lens/analyzers/generated_columns.rb
+++ b/lib/rails_lens/analyzers/generated_columns.rb
@@ -45,10 +45,10 @@ module RailsLens
           }
         end
       rescue ActiveRecord::StatementInvalid => e
-        Rails.logger.debug { "Failed to detect generated columns for #{table_name}: #{e.message}" }
+        RailsLens.logger.debug { "Failed to detect generated columns for #{table_name}: #{e.message}" }
         []
       rescue PG::Error => e
-        Rails.logger.debug { "PostgreSQL error detecting generated columns: #{e.message}" }
+        RailsLens.logger.debug { "PostgreSQL error detecting generated columns: #{e.message}" }
         []
       end
     end

--- a/lib/rails_lens/analyzers/inheritance.rb
+++ b/lib/rails_lens/analyzers/inheritance.rb
@@ -33,10 +33,10 @@ module RailsLens
         model_class.respond_to?(:delegated_type_reflection) &&
           model_class.delegated_type_reflection.present?
       rescue NoMethodError => e
-        Rails.logger.debug { "Failed to check delegated type for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Failed to check delegated type for #{model_class.name}: #{e.message}" }
         false
       rescue NameError => e
-        Rails.logger.debug { "Name error checking delegated type: #{e.message}" }
+        RailsLens.logger.debug { "Name error checking delegated type: #{e.message}" }
         false
       end
 
@@ -91,10 +91,10 @@ module RailsLens
 
         subclasses.sort
       rescue NoMethodError => e
-        Rails.logger.debug { "Failed to find STI subclasses for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Failed to find STI subclasses for #{model_class.name}: #{e.message}" }
         []
       rescue NameError => e
-        Rails.logger.debug { "Name error finding STI subclasses: #{e.message}" }
+        RailsLens.logger.debug { "Name error finding STI subclasses: #{e.message}" }
         []
       end
 
@@ -110,10 +110,10 @@ module RailsLens
 
         siblings.sort
       rescue NoMethodError => e
-        Rails.logger.debug { "Failed to find STI siblings for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Failed to find STI siblings for #{model_class.name}: #{e.message}" }
         []
       rescue NameError => e
-        Rails.logger.debug { "Name error finding STI siblings: #{e.message}" }
+        RailsLens.logger.debug { "Name error finding STI siblings: #{e.message}" }
         []
       end
 
@@ -136,10 +136,10 @@ module RailsLens
 
         types.uniq.sort
       rescue ActiveRecord::StatementInvalid => e
-        Rails.logger.debug { "Database error finding delegated types for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Database error finding delegated types for #{model_class.name}: #{e.message}" }
         []
       rescue ActiveRecord::ConnectionNotEstablished => e
-        Rails.logger.debug { "No database connection for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "No database connection for #{model_class.name}: #{e.message}" }
         []
       end
 
@@ -201,10 +201,10 @@ module RailsLens
           .compact
           .sort
       rescue ActiveRecord::StatementInvalid => e
-        Rails.logger.debug { "Database error finding polymorphic types for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Database error finding polymorphic types for #{model_class.name}: #{e.message}" }
         []
       rescue ActiveRecord::ConnectionNotEstablished => e
-        Rails.logger.debug { "No database connection for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "No database connection for #{model_class.name}: #{e.message}" }
         []
       end
     end

--- a/lib/rails_lens/analyzers/notes.rb
+++ b/lib/rails_lens/analyzers/notes.rb
@@ -11,15 +11,15 @@ module RailsLens
         @connection = model_class.connection
         @table_name = model_class.table_name
       rescue ActiveRecord::ConnectionNotEstablished => e
-        Rails.logger.debug { "No database connection for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "No database connection for #{model_class.name}: #{e.message}" }
         @connection = nil
         @table_name = nil
       rescue NoMethodError => e
-        Rails.logger.debug { "Failed to initialize Notes analyzer for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Failed to initialize Notes analyzer for #{model_class.name}: #{e.message}" }
         @connection = nil
         @table_name = nil
       rescue RuntimeError => e
-        Rails.logger.debug { "Runtime error initializing Notes analyzer for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Runtime error initializing Notes analyzer for #{model_class.name}: #{e.message}" }
         @connection = nil
         @table_name = nil
       end
@@ -48,10 +48,10 @@ module RailsLens
 
         notes.compact.uniq
       rescue ActiveRecord::StatementInvalid => e
-        Rails.logger.debug { "Database error analyzing notes for #{@table_name}: #{e.message}" }
+        RailsLens.logger.debug { "Database error analyzing notes for #{@table_name}: #{e.message}" }
         nil
       rescue NoMethodError => e
-        Rails.logger.debug { "Method error analyzing notes for #{@table_name}: #{e.message}" }
+        RailsLens.logger.debug { "Method error analyzing notes for #{@table_name}: #{e.message}" }
         nil
       end
 
@@ -72,7 +72,7 @@ module RailsLens
 
         notes
       rescue StandardError => e
-        Rails.logger.debug { "Error checking view readonly status for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Error checking view readonly status for #{model_class.name}: #{e.message}" }
         []
       end
 
@@ -101,7 +101,7 @@ module RailsLens
 
         notes
       rescue StandardError => e
-        Rails.logger.debug { "Error analyzing view gotchas for #{model_class.name}: #{e.message}" }
+        RailsLens.logger.debug { "Error analyzing view gotchas for #{model_class.name}: #{e.message}" }
         []
       end
 
@@ -341,10 +341,10 @@ module RailsLens
           inverse = association.klass.reflect_on_association(association.inverse_of&.name || model_class.name.underscore.pluralize)
           inverse && inverse.macro == :has_many && !association.options[:counter_cache]
         rescue NameError => e
-          Rails.logger.debug { "Failed to check counter cache for association: #{e.message}" }
+          RailsLens.logger.debug { "Failed to check counter cache for association: #{e.message}" }
           false
         rescue NoMethodError => e
-          Rails.logger.debug { "Method error checking counter cache: #{e.message}" }
+          RailsLens.logger.debug { "Method error checking counter cache: #{e.message}" }
           false
         end
       end
@@ -425,7 +425,7 @@ module RailsLens
           false
         end
       rescue StandardError => e
-        Rails.logger.debug { "Error checking view existence for #{view_name}: #{e.message}" }
+        RailsLens.logger.debug { "Error checking view existence for #{view_name}: #{e.message}" }
         false
       end
     end

--- a/lib/rails_lens/cli.rb
+++ b/lib/rails_lens/cli.rb
@@ -79,7 +79,7 @@ module RailsLens
 
         # Transform CLI options to visualizer options
         visualizer_options = options.dup
-        visualizer_options[:output_dir] = options[:output] || 'output'
+        visualizer_options[:output_dir] = options[:output] if options[:output]
 
         commands = Commands.new(self)
         commands.generate_erd(visualizer_options)

--- a/lib/rails_lens/cli_error_handler.rb
+++ b/lib/rails_lens/cli_error_handler.rb
@@ -79,7 +79,7 @@ module RailsLens
         say error.backtrace.first(10).join("\n"), :yellow
       end
 
-      say "\nPlease report this issue at: https://github.com/your-org/rails_lens/issues", :cyan
+      say "\nPlease report this issue at: https://github.com/seuros/rails_lens/issues", :cyan
       exit 1
     end
   end

--- a/lib/rails_lens/configuration.rb
+++ b/lib/rails_lens/configuration.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module RailsLens
+  module Configuration
+    extend ActiveSupport::Concern
+
+    included do
+      # Add configuration for error handling
+      config_accessor :verbose, default: false
+      config_accessor :debug, default: false
+      config_accessor :raise_on_error, default: false
+
+      # Logger configuration
+      config_accessor :logger
+
+      # Configuration using ActiveSupport::Configurable
+      config_accessor :annotations do
+        {
+          position: :before,
+          format: :rdoc
+        }
+      end
+
+      config_accessor :erd do
+        {
+          output_dir: 'doc/erd',
+          orientation: 'TB',
+          theme: true,
+          default_colors: %w[
+            lightblue
+            lightcoral
+            lightgreen
+            lightyellow
+            plum
+            lightcyan
+            lightgray
+          ]
+        }
+      end
+
+      config_accessor :schema do
+        {
+          adapter: :auto,
+          include_notes: true,
+          exclude_tables: nil, # Will use ActiveRecord::SchemaDumper.ignore_tables if nil
+          format_options: {
+            show_defaults: true,
+            show_comments: true,
+            show_foreign_keys: true,
+            show_indexes: true,
+            show_check_constraints: true
+          }
+        }
+      end
+
+      config_accessor :extensions do
+        {
+          enabled: true,
+          autoload: true,
+          interface_version: '1.0',
+          ignore: [],
+          custom_paths: [],
+          error_reporting: :warn,    # :silent, :warn, :verbose
+          fail_safe_mode: true,      # Continue processing if extensions fail
+          track_health: false        # Track extension success/failure rates
+        }
+      end
+
+      config_accessor :routes do
+        {
+          enabled: true,
+          include_defaults: true,
+          include_constraints: true,
+          pattern: '**/*_controller.rb',
+          exclusion_pattern: 'vendor/**/*_controller.rb'
+        }
+      end
+
+      config_accessor :mailers do
+        {
+          enabled: true,
+          include_templates: true,
+          include_delivery_methods: true,
+          include_variables: true,
+          include_locales: true,
+          include_defaults: true,
+          pattern: '**/*_mailer.rb',
+          exclusion_pattern: 'vendor/**/*_mailer.rb'
+        }
+      end
+    end
+  end
+end

--- a/lib/rails_lens/erd/visualizer.rb
+++ b/lib/rails_lens/erd/visualizer.rb
@@ -93,14 +93,14 @@ module RailsLens
             if columns_added
               output << '  }'
               output << ''
-              Rails.logger.debug { "Added entity: #{model_display_name}" } if options[:verbose]
+              RailsLens.logger.debug { "Added entity: #{model_display_name}" } if options[:verbose]
             else
               # Remove the opening brace if no columns were added
               output.slice!(brace_position..-1)
-              Rails.logger.debug { "Skipped entity #{model_display_name}: no columns found" } if options[:verbose]
+              RailsLens.logger.debug { "Skipped entity #{model_display_name}: no columns found" } if options[:verbose]
             end
           rescue StandardError => e
-            Rails.logger.debug { "Warning: Could not add entity #{model.name}: #{e.message}" }
+            RailsLens.logger.debug { "Warning: Could not add entity #{model.name}: #{e.message}" }
             # Remove any partial entity content added since the opening brace
             if output.size > brace_position
               output.slice!(brace_position..-1)
@@ -131,7 +131,7 @@ module RailsLens
         # Save output
         filename = save_output(mermaid_output, 'mmd')
 
-        Rails.logger.debug 'ERD generated successfully!'
+        RailsLens.logger.debug 'ERD generated successfully!'
         filename # Return the filename instead of content
       end
 
@@ -211,7 +211,7 @@ module RailsLens
       def add_belongs_to_relationship(output, model, association, target_model)
         output << "  #{format_model_name(model)} }o--|| #{format_model_name(target_model)} : \"#{association.name}\""
       rescue StandardError => e
-        Rails.logger.debug do
+        RailsLens.logger.debug do
           "Warning: Could not add belongs_to relationship #{model.name} -> #{association.name}: #{e.message}"
         end
       end
@@ -219,7 +219,7 @@ module RailsLens
       def add_has_one_relationship(output, model, association, target_model)
         output << "  #{format_model_name(model)} ||--o| #{format_model_name(target_model)} : \"#{association.name}\""
       rescue StandardError => e
-        Rails.logger.debug do
+        RailsLens.logger.debug do
           "Warning: Could not add has_one relationship #{model.name} -> #{association.name}: #{e.message}"
         end
       end
@@ -227,7 +227,7 @@ module RailsLens
       def add_has_many_relationship(output, model, association, target_model)
         output << "  #{format_model_name(model)} ||--o{ #{format_model_name(target_model)} : \"#{association.name}\""
       rescue StandardError => e
-        Rails.logger.debug do
+        RailsLens.logger.debug do
           "Warning: Could not add has_many relationship #{model.name} -> #{association.name}: #{e.message}"
         end
       end
@@ -235,7 +235,7 @@ module RailsLens
       def add_habtm_relationship(output, model, association, target_model)
         output << "  #{format_model_name(model)} }o--o{ #{format_model_name(target_model)} : \"#{association.name}\""
       rescue StandardError => e
-        Rails.logger.debug do
+        RailsLens.logger.debug do
           "Warning: Could not add habtm relationship #{model.name} -> #{association.name}: #{e.message}"
         end
       end
@@ -294,7 +294,7 @@ module RailsLens
             output << "  class #{model_display_name} tableEntity"
           end
         rescue StandardError => e
-          Rails.logger.debug { "Warning: Could not apply styling to #{model.name}: #{e.message}" }
+          RailsLens.logger.debug { "Warning: Could not apply styling to #{model.name}: #{e.message}" }
         end
 
         output << ''
@@ -308,7 +308,7 @@ module RailsLens
           db_name = model.connection.pool.db_config.name
           grouped[db_name] << model
         rescue StandardError => e
-          Rails.logger.debug { "Warning: Could not determine database for #{model.name}: #{e.message}" }
+          RailsLens.logger.debug { "Warning: Could not determine database for #{model.name}: #{e.message}" }
           grouped['unknown'] << model
         end
 
@@ -368,7 +368,7 @@ module RailsLens
         filename = File.join(output_dir, "erd.#{extension}")
         File.write(filename, content)
 
-        Rails.logger.debug { "ERD saved to: #{filename}" }
+        RailsLens.logger.debug { "ERD saved to: #{filename}" }
         filename # Return the filename
       end
     end

--- a/lib/rails_lens/errors.rb
+++ b/lib/rails_lens/errors.rb
@@ -47,7 +47,7 @@ module RailsLens
         message = build_error_message(error, context)
 
         # Use Rails logger for verbose mode
-        RailsLens.logger&.error message
+        RailsLens.logger.error message
 
         # Use kernel output for debug mode to ensure visibility
         return unless RailsLens.debug

--- a/lib/rails_lens/errors.rb
+++ b/lib/rails_lens/errors.rb
@@ -47,12 +47,12 @@ module RailsLens
         message = build_error_message(error, context)
 
         # Use Rails logger for verbose mode
-        Rails.logger&.error message
+        RailsLens.logger&.error message
 
         # Use kernel output for debug mode to ensure visibility
         return unless RailsLens.debug
 
-        Rails.logger.debug message
+        RailsLens.logger.debug message
       end
 
       def handle(context = {})

--- a/lib/rails_lens/extension_loader.rb
+++ b/lib/rails_lens/extension_loader.rb
@@ -229,16 +229,16 @@ module RailsLens
         when :silent
           # Do nothing
         when :warn
-          if Rails.logger
-            Rails.logger.warn "[RailsLens Extensions] #{message}#{" (#{context})" if context}"
+          if RailsLens.logger
+            RailsLens.logger.warn "[RailsLens Extensions] #{message}#{" (#{context})" if context}"
           else
-            Rails.logger.debug { "Warning: [RailsLens Extensions] #{message}#{" (#{context})" if context}" }
+            RailsLens.logger.debug { "Warning: [RailsLens Extensions] #{message}#{" (#{context})" if context}" }
           end
         when :verbose
-          if Rails.logger
-            Rails.logger.error "[RailsLens Extensions] #{message}#{" (#{context})" if context}"
+          if RailsLens.logger
+            RailsLens.logger.error "[RailsLens Extensions] #{message}#{" (#{context})" if context}"
           else
-            Rails.logger.debug { "Error: [RailsLens Extensions] #{message}#{" (#{context})" if context}" }
+            RailsLens.logger.debug { "Error: [RailsLens Extensions] #{message}#{" (#{context})" if context}" }
           end
         end
       end

--- a/lib/rails_lens/extension_loader.rb
+++ b/lib/rails_lens/extension_loader.rb
@@ -229,17 +229,9 @@ module RailsLens
         when :silent
           # Do nothing
         when :warn
-          if RailsLens.logger
-            RailsLens.logger.warn "[RailsLens Extensions] #{message}#{" (#{context})" if context}"
-          else
-            RailsLens.logger.debug { "Warning: [RailsLens Extensions] #{message}#{" (#{context})" if context}" }
-          end
+          RailsLens.logger.warn "[RailsLens Extensions] #{message}#{" (#{context})" if context}"
         when :verbose
-          if RailsLens.logger
-            RailsLens.logger.error "[RailsLens Extensions] #{message}#{" (#{context})" if context}"
-          else
-            RailsLens.logger.debug { "Error: [RailsLens Extensions] #{message}#{" (#{context})" if context}" }
-          end
+          RailsLens.logger.error "[RailsLens Extensions] #{message}#{" (#{context})" if context}"
         end
       end
 

--- a/lib/rails_lens/extensions/base.rb
+++ b/lib/rails_lens/extensions/base.rb
@@ -176,17 +176,9 @@ module RailsLens
         when :silent
           # Do nothing
         when :warn
-          if RailsLens.logger
-            RailsLens.logger.warn "[RailsLens Extensions] Method failed: #{message} (#{context})"
-          else
-            RailsLens.logger.debug { "Warning: [RailsLens Extensions] Method failed: #{message} (#{context})" }
-          end
+          RailsLens.logger.warn "[RailsLens Extensions] Method failed: #{message} (#{context})"
         when :verbose
-          if RailsLens.logger
-            RailsLens.logger.error "[RailsLens Extensions] Method failed: #{message} (#{context})"
-          else
-            RailsLens.logger.debug { "Error: [RailsLens Extensions] Method failed: #{message} (#{context})" }
-          end
+          RailsLens.logger.error "[RailsLens Extensions] Method failed: #{message} (#{context})"
         end
       end
     end

--- a/lib/rails_lens/extensions/base.rb
+++ b/lib/rails_lens/extensions/base.rb
@@ -176,16 +176,16 @@ module RailsLens
         when :silent
           # Do nothing
         when :warn
-          if Rails.logger
-            Rails.logger.warn "[RailsLens Extensions] Method failed: #{message} (#{context})"
+          if RailsLens.logger
+            RailsLens.logger.warn "[RailsLens Extensions] Method failed: #{message} (#{context})"
           else
-            Rails.logger.debug { "Warning: [RailsLens Extensions] Method failed: #{message} (#{context})" }
+            RailsLens.logger.debug { "Warning: [RailsLens Extensions] Method failed: #{message} (#{context})" }
           end
         when :verbose
-          if Rails.logger
-            Rails.logger.error "[RailsLens Extensions] Method failed: #{message} (#{context})"
+          if RailsLens.logger
+            RailsLens.logger.error "[RailsLens Extensions] Method failed: #{message} (#{context})"
           else
-            Rails.logger.debug { "Error: [RailsLens Extensions] Method failed: #{message} (#{context})" }
+            RailsLens.logger.debug { "Error: [RailsLens Extensions] Method failed: #{message} (#{context})" }
           end
         end
       end

--- a/lib/rails_lens/model_detector.rb
+++ b/lib/rails_lens/model_detector.rb
@@ -126,7 +126,7 @@ module RailsLens
         trace_filtering = options[:trace_filtering] || ENV.fetch('RAILS_LENS_TRACE_FILTERING', nil)
 
         original_count = models.size
-        Rails.logger.debug { "[ModelDetector] Starting with #{original_count} models" } if trace_filtering
+        RailsLens.logger.debug { "[ModelDetector] Starting with #{original_count} models" } if trace_filtering
 
         # Remove anonymous classes and non-class objects
         before_count = models.size
@@ -157,7 +157,7 @@ module RailsLens
               end
             end
             if excluded && trace_filtering
-              Rails.logger.debug do
+              RailsLens.logger.debug do
                 "[ModelDetector] Excluding #{model.name}: matched exclude pattern"
               end
             end
@@ -182,12 +182,12 @@ module RailsLens
               end
             end
             if included && trace_filtering
-              Rails.logger.debug do
+              RailsLens.logger.debug do
                 "[ModelDetector] Including #{model.name}: matched include pattern"
               end
             end
             if !included && trace_filtering
-              Rails.logger.debug { "[ModelDetector] Excluding #{model.name}: did not match include patterns" }
+              RailsLens.logger.debug { "[ModelDetector] Excluding #{model.name}: did not match include patterns" }
             end
             included
           end
@@ -203,13 +203,13 @@ module RailsLens
         log_filter_step('Abstract/invalid table removal', before_count, models.size, trace_filtering)
 
         # Exclude tables from configuration
-        excluded_tables = RailsLens.config.schema[:exclude_tables]
+        excluded_tables = RailsLens.excluded_tables
         before_count = models.size
         models = models.reject do |model|
           begin
             excluded = excluded_tables.include?(model.table_name)
             if excluded && trace_filtering
-              Rails.logger.debug do
+              RailsLens.logger.debug do
                 "[ModelDetector] Excluding #{model.name}: table '#{model.table_name}' in exclude_tables config"
               end
             end
@@ -218,7 +218,7 @@ module RailsLens
             # This can happen in multi-db setups if the connection is not yet established
             # We will assume the model should be kept in this case
             if trace_filtering
-              Rails.logger.debug do
+              RailsLens.logger.debug do
                 "[ModelDetector] Keeping #{model.name}: connection not defined, assuming keep"
               end
             end
@@ -226,7 +226,7 @@ module RailsLens
           end
         rescue ActiveRecord::StatementInvalid => e
           if trace_filtering
-            Rails.logger.debug do
+            RailsLens.logger.debug do
               "[ModelDetector] Keeping #{model.name}: database error checking exclude_tables - #{e.message}"
             end
           end
@@ -235,11 +235,11 @@ module RailsLens
         log_filter_step('Configuration exclude_tables', before_count, models.size, trace_filtering)
 
         if trace_filtering
-          Rails.logger.debug do
+          RailsLens.logger.debug do
             "[ModelDetector] Final result: #{models.size} models after all filtering"
           end
         end
-        Rails.logger.debug { "[ModelDetector] Final models: #{models.map(&:name).join(', ')}" } if trace_filtering
+        RailsLens.logger.debug { "[ModelDetector] Final models: #{models.map(&:name).join(', ')}" } if trace_filtering
 
         models
       end
@@ -249,11 +249,11 @@ module RailsLens
 
         filtered_count = before_count - after_count
         if filtered_count.positive?
-          Rails.logger.debug do
+          RailsLens.logger.debug do
             "[ModelDetector] #{step_name}: filtered out #{filtered_count} models (#{before_count} -> #{after_count})"
           end
         else
-          Rails.logger.debug { "[ModelDetector] #{step_name}: no models filtered (#{after_count} remain)" }
+          RailsLens.logger.debug { "[ModelDetector] #{step_name}: no models filtered (#{after_count} remain)" }
         end
       end
 
@@ -301,7 +301,7 @@ module RailsLens
 
           if trace_filtering
             action = should_exclude ? 'Excluding' : 'Keeping'
-            Rails.logger.debug { "[ModelDetector] #{action} #{model.name}: #{reason}" }
+            RailsLens.logger.debug { "[ModelDetector] #{action} #{model.name}: #{reason}" }
           end
 
           { model: model, exclude: should_exclude }
@@ -408,7 +408,7 @@ module RailsLens
 
         if trace_filtering
           action = should_exclude ? 'Excluding' : 'Keeping'
-          Rails.logger.debug { "[ModelDetector] #{action} #{model.name}: #{reason}" }
+          RailsLens.logger.debug { "[ModelDetector] #{action} #{model.name}: #{reason}" }
         end
 
         { model: model, exclude: should_exclude }

--- a/lib/rails_lens/schema/adapters/mysql.rb
+++ b/lib/rails_lens/schema/adapters/mysql.rb
@@ -144,10 +144,10 @@ module RailsLens
             result[1] # Engine is typically the second column
           end
         rescue ActiveRecord::StatementInvalid => e
-          Rails.logger.debug { "Failed to fetch storage engine for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch storage engine for #{table_name}: #{e.message}" }
           nil
         rescue => e
-          Rails.logger.debug { "MySQL error fetching storage engine: #{e.message}" }
+          RailsLens.logger.debug { "MySQL error fetching storage engine: #{e.message}" }
           nil
         end
 
@@ -164,10 +164,10 @@ module RailsLens
 
           collation&.split('_')&.first
         rescue ActiveRecord::StatementInvalid => e
-          Rails.logger.debug { "Failed to fetch charset for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch charset for #{table_name}: #{e.message}" }
           nil
         rescue => e
-          Rails.logger.debug { "MySQL error fetching charset: #{e.message}" }
+          RailsLens.logger.debug { "MySQL error fetching charset: #{e.message}" }
           nil
         end
 
@@ -182,10 +182,10 @@ module RailsLens
             result[14] # Collation is typically the 15th column
           end
         rescue ActiveRecord::StatementInvalid => e
-          Rails.logger.debug { "Failed to fetch collation for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch collation for #{table_name}: #{e.message}" }
           nil
         rescue => e
-          Rails.logger.debug { "MySQL error fetching collation: #{e.message}" }
+          RailsLens.logger.debug { "MySQL error fetching collation: #{e.message}" }
           nil
         end
 
@@ -229,11 +229,11 @@ module RailsLens
           count.to_i.positive?
         rescue ActiveRecord::StatementInvalid => e
           # Table doesn't exist or no permission to query information_schema
-          Rails.logger.debug { "Failed to check partitions for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to check partitions for #{table_name}: #{e.message}" }
           false
         rescue => e
           # MySQL specific errors (connection issues, etc)
-          Rails.logger.debug { "MySQL error checking partitions: #{e.message}" }
+          RailsLens.logger.debug { "MySQL error checking partitions: #{e.message}" }
           false
         end
 
@@ -259,10 +259,10 @@ module RailsLens
           end
         rescue ActiveRecord::StatementInvalid => e
           # Permission denied or table doesn't exist
-          Rails.logger.debug { "Failed to fetch partitions for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch partitions for #{table_name}: #{e.message}" }
         rescue => e
           # MySQL specific errors
-          Rails.logger.debug { "MySQL error fetching partitions: #{e.message}" }
+          RailsLens.logger.debug { "MySQL error fetching partitions: #{e.message}" }
         end
 
         def add_partitions_toml(lines)
@@ -297,10 +297,10 @@ module RailsLens
           lines << ']'
         rescue ActiveRecord::StatementInvalid => e
           # Permission denied or table doesn't exist
-          Rails.logger.debug { "Failed to fetch partitions for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch partitions for #{table_name}: #{e.message}" }
         rescue => e
           # MySQL specific errors
-          Rails.logger.debug { "MySQL error fetching partitions: #{e.message}" }
+          RailsLens.logger.debug { "MySQL error fetching partitions: #{e.message}" }
         end
 
         def add_view_dependencies_toml(lines, view_info)
@@ -345,7 +345,7 @@ module RailsLens
             dependencies: row[1].to_s.split(',').reject(&:empty?)
           }
         rescue ActiveRecord::StatementInvalid, Mysql2::Error => e
-          Rails.logger.debug { "Failed to fetch view metadata for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch view metadata for #{table_name}: #{e.message}" }
           nil
         end
 

--- a/lib/rails_lens/schema/adapters/postgresql.rb
+++ b/lib/rails_lens/schema/adapters/postgresql.rb
@@ -150,11 +150,11 @@ module RailsLens
           end
         rescue ActiveRecord::StatementInvalid => e
           # Table doesn't exist or other database error
-          Rails.logger.debug { "Failed to fetch check constraints for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch check constraints for #{table_name}: #{e.message}" }
           []
         rescue PG::Error => e
           # PostgreSQL specific errors
-          Rails.logger.debug { "PostgreSQL error fetching check constraints: #{e.message}" }
+          RailsLens.logger.debug { "PostgreSQL error fetching check constraints: #{e.message}" }
           []
         end
 
@@ -164,11 +164,11 @@ module RailsLens
           connection.column_comment(table_name, column_name)
         rescue ActiveRecord::StatementInvalid => e
           # Table or column doesn't exist
-          Rails.logger.debug { "Failed to fetch column comment for #{table_name}.#{column_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch column comment for #{table_name}.#{column_name}: #{e.message}" }
           nil
         rescue PG::Error => e
           # PostgreSQL specific errors
-          Rails.logger.debug { "PostgreSQL error fetching column comment: #{e.message}" }
+          RailsLens.logger.debug { "PostgreSQL error fetching column comment: #{e.message}" }
           nil
         end
 
@@ -178,11 +178,11 @@ module RailsLens
           connection.table_comment(table_name)
         rescue ActiveRecord::StatementInvalid => e
           # Table doesn't exist
-          Rails.logger.debug { "Failed to fetch table comment for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch table comment for #{table_name}: #{e.message}" }
           nil
         rescue PG::Error => e
           # PostgreSQL specific errors
-          Rails.logger.debug { "PostgreSQL error fetching table comment: #{e.message}" }
+          RailsLens.logger.debug { "PostgreSQL error fetching table comment: #{e.message}" }
           nil
         end
 
@@ -292,7 +292,7 @@ module RailsLens
             dependencies: row[2] || []
           }
         rescue ActiveRecord::StatementInvalid, PG::Error => e
-          Rails.logger.debug { "Failed to fetch view metadata for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch view metadata for #{table_name}: #{e.message}" }
           nil
         end
 

--- a/lib/rails_lens/schema/adapters/sqlite3.rb
+++ b/lib/rails_lens/schema/adapters/sqlite3.rb
@@ -93,10 +93,10 @@ module RailsLens
             lines << 'FOREIGN_KEYS_ENABLED: false' if fk_status && fk_status['foreign_keys'].zero?
           rescue ActiveRecord::StatementInvalid => e
             # SQLite doesn't recognize the pragma or access denied
-            Rails.logger.debug { "Failed to fetch SQLite foreign_keys pragma: #{e.message}" }
+            RailsLens.logger.debug { "Failed to fetch SQLite foreign_keys pragma: #{e.message}" }
           rescue SQLite3::Exception => e
             # SQLite specific errors (database locked, etc)
-            Rails.logger.debug { "SQLite error fetching pragmas: #{e.message}" }
+            RailsLens.logger.debug { "SQLite error fetching pragmas: #{e.message}" }
           end
         end
 
@@ -113,10 +113,10 @@ module RailsLens
             end
           rescue ActiveRecord::StatementInvalid => e
             # SQLite doesn't recognize the pragma or access denied
-            Rails.logger.debug { "Failed to fetch SQLite foreign_keys pragma: #{e.message}" }
+            RailsLens.logger.debug { "Failed to fetch SQLite foreign_keys pragma: #{e.message}" }
           rescue SQLite3::Exception => e
             # SQLite specific errors (database locked, etc)
-            Rails.logger.debug { "SQLite error fetching pragmas: #{e.message}" }
+            RailsLens.logger.debug { "SQLite error fetching pragmas: #{e.message}" }
           end
         end
 
@@ -164,7 +164,7 @@ module RailsLens
             dependencies: tables.sort
           }
         rescue ActiveRecord::StatementInvalid, SQLite3::Exception => e
-          Rails.logger.debug { "Failed to fetch view metadata for #{table_name}: #{e.message}" }
+          RailsLens.logger.debug { "Failed to fetch view metadata for #{table_name}: #{e.message}" }
           nil
         end
 

--- a/test/dummy/.rails-lens.yml
+++ b/test/dummy/.rails-lens.yml
@@ -1,3 +1,12 @@
-format_options:
-  show_indexes: false
-  show_foreign_keys: false
+# Rails Lens configuration for dummy app
+schema:
+  include_notes: true
+  format_options:
+    show_indexes: false
+    show_foreign_keys: false
+
+extensions:
+  enabled: true
+
+erd:
+  output_dir: doc/diagrams

--- a/test/dummy/app/models/diet_relationship.rb
+++ b/test/dummy/app/models/diet_relationship.rb
@@ -15,16 +15,6 @@
 #   { name = "evidence_type", type = "string", nullable = true }
 # ]
 #
-# indexes = [
-#   { name = "index_diet_relationships_on_prey_id", columns = ["prey_id"] },
-#   { name = "index_diet_relationships_on_predator_id", columns = ["predator_id"] }
-# ]
-#
-# foreign_keys = [
-#   { column = "prey_id", references_table = "species", references_column = "id" },
-#   { column = "predator_id", references_table = "species", references_column = "id" }
-# ]
-#
 # == Enums
 # - evidence_type: { stomach_contents: "stomach_contents", coprolite: "coprolite", bite_marks: "bite_marks", tooth_marks: "tooth_marks", behavioral: "behavioral", anatomical: "anatomical" } (string)
 #

--- a/test/dummy/app/models/fossil_discovery.rb
+++ b/test/dummy/app/models/fossil_discovery.rb
@@ -18,16 +18,6 @@
 #   { name = "fossil_type", type = "string", nullable = true }
 # ]
 #
-# indexes = [
-#   { name = "index_fossil_discoveries_on_excavation_site_id", columns = ["excavation_site_id"] },
-#   { name = "index_fossil_discoveries_on_dinosaur_id", columns = ["dinosaur_id"] }
-# ]
-#
-# foreign_keys = [
-#   { column = "excavation_site_id", references_table = "excavation_sites", references_column = "id" },
-#   { column = "dinosaur_id", references_table = "dinosaurs", references_column = "id" }
-# ]
-#
 # == Enums
 # - preservation_quality: { excellent: "excellent", good: "good", fair: "fair", poor: "poor", fragmentary: "fragmentary" } (string)
 # - fossil_type: { skeleton: "skeleton", skull: "skull", teeth: "teeth", tracks: "tracks", eggs: "eggs", coprolite: "coprolite", skin_impression: "skin_impression" } (string)

--- a/test/dummy/app/models/species.rb
+++ b/test/dummy/app/models/species.rb
@@ -16,14 +16,6 @@
 #   { name = "locomotion", type = "string", nullable = true }
 # ]
 #
-# indexes = [
-#   { name = "index_species_on_family_id", columns = ["family_id"] }
-# ]
-#
-# foreign_keys = [
-#   { column = "family_id", references_table = "families", references_column = "id" }
-# ]
-#
 # == Notes
 # - Association 'family' should specify inverse_of
 # - Association 'dinosaurs' has N+1 query risk. Consider using includes/preload


### PR DESCRIPTION
- Add RailsLens.logger with fallback to STDOUT when Rails.logger is not available
- Update exclude_tables to use ActiveRecord::SchemaDumper.ignore_tables by default
- Update .rails-lens.yml example to use correct structure