### PR TITLE
fix: support PostgreSQL schema-qualified table names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,24 +12,24 @@ jobs:
     name: Lint
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      
+
       - name: Run RuboCop
         run: bundle exec rubocop --parallel
 
   test:
     runs-on: ubuntu-latest
     name: Test (Rails ${{ matrix.rails }})
-    
+
     strategy:
       fail-fast: false
       matrix:
-        rails: ['7.2', '8.0']
-    
+        rails: ['7.2', '8.0', '8.1.beta1']
+
     services:
       postgres:
         image: ghcr.io/seuros/postgis-with-extensions:17-4
@@ -44,7 +44,7 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-      
+
       mysql:
         image: mysql:8
         env:
@@ -60,6 +60,7 @@ jobs:
 
     env:
       RAILS_ENV: test
+      RAILS_VERSION: ${{ matrix.rails }}
       POSTGRES_HOST: localhost
       POSTGRES_USER: rails_lens_user
       POSTGRES_PASSWORD: galactic_spaceships_2025
@@ -71,12 +72,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
-      
+          bundler-cache: false
+
+      - name: Install dependencies with Rails ${{ matrix.rails }}
+        run: |
+          gem install bundler
+          bundle config set --local path 'vendor/bundle'
+          bundle install --jobs 4 --retry 3
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -86,7 +93,7 @@ jobs:
             libsqlite3-dev \
             postgresql-client \
             mysql-client
-      
+
       - name: Set up test databases
         run: |
           cd test/dummy
@@ -98,21 +105,21 @@ jobs:
           # Create and migrate all databases in multi-database setup
           bundle exec rails db:create:all RAILS_ENV=test
           bundle exec rails db:migrate RAILS_ENV=test
-      
+
       - name: Run tests
         run: bundle exec rake test
-      
+
       - name: Test CLI commands
         run: |
           cd test/dummy
-          
+
           # Test annotation commands
           bundle exec rails_lens annotate --all
           bundle exec rails_lens remove --all
-          
+
           # Test ERD generation
           bundle exec rails_lens erd --output tmp/test_erd
-          
+
           # Test version command
           bundle exec rails_lens version
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,16 @@ gem 'rake', '~> 13.0'
 gem 'minitest', '~> 5.17'
 gem 'minitest-reporters', '~> 1.6'
 
-gem 'actionmailer', '>= 7.2.0'
+# Support testing against different Rails versions
+if ENV['RAILS_VERSION']
+  rails_version = ENV['RAILS_VERSION']
+  gem 'actionmailer', "~> #{rails_version}.0"
+  gem 'activerecord', "~> #{rails_version}.0"
+  gem 'railties', "~> #{rails_version}.0"
+else
+  gem 'actionmailer', '>= 7.2.0'
+end
+
 gem 'activerecord-postgis'
 gem 'closure_tree'
 gem 'dotenv', '~> 3.0'

--- a/test/rails_lens/schema/adapters/base_test.rb
+++ b/test/rails_lens/schema/adapters/base_test.rb
@@ -36,6 +36,50 @@ module RailsLens
           assert_kind_of String, dialect
           assert_not_empty dialect
         end
+
+        def test_unqualified_table_name_with_simple_name
+          adapter = Base.new(@connection, 'users')
+
+          assert_equal 'users', adapter.send(:unqualified_table_name)
+        end
+
+        def test_unqualified_table_name_with_schema_qualified_name
+          adapter = Base.new(@connection, 'public.users')
+
+          assert_equal 'users', adapter.send(:unqualified_table_name)
+        end
+
+        def test_unqualified_table_name_with_custom_schema
+          adapter = Base.new(@connection, 'cms.posts')
+
+          assert_equal 'posts', adapter.send(:unqualified_table_name)
+        end
+
+        def test_unqualified_table_name_caching
+          adapter = Base.new(@connection, 'audit.events')
+
+          # First call
+          result1 = adapter.send(:unqualified_table_name)
+          # Second call should use cached value
+          result2 = adapter.send(:unqualified_table_name)
+
+          assert_equal result1, result2
+          assert_equal 'events', result1
+        end
+
+        def test_index_columns_array_handling
+          # Test that Array() properly handles both string and array columns
+          Base.new(@connection, 'users')
+
+          # Create mock indexes with different column formats using Struct
+          mock_index = Struct.new(:columns)
+          string_columns_index = mock_index.new('email')
+          array_columns_index = mock_index.new(%w[name email])
+
+          # Verify both formats work with Array() wrapper
+          assert_equal ['email'], Array(string_columns_index.columns)
+          assert_equal %w[name email], Array(array_columns_index.columns)
+        end
       end
     end
   end

--- a/test/rails_lens/schema/adapters/postgresql_test.rb
+++ b/test/rails_lens/schema/adapters/postgresql_test.rb
@@ -38,6 +38,72 @@ module RailsLens
 
           assert_equal 'PostgreSQL', dialect
         end
+
+        def test_schema_qualified_table_name_extraction
+          adapter = Postgresql.new(@connection, 'audit.test_table')
+
+          # Test unqualified_table_name helper extracts correctly
+          assert_equal 'test_table', adapter.send(:unqualified_table_name)
+
+          # Test schema_name extraction
+          assert_equal 'audit', adapter.send(:schema_name)
+        end
+
+        def test_schema_qualified_table_name_in_annotation
+          # Use existing AuditLog model with schema-qualified table name
+          adapter = Postgresql.new(@connection, 'audit.audit_logs')
+          annotation = adapter.generate_annotation(AuditLog)
+
+          # Verify schema-qualified table name is preserved
+          assert_includes annotation, 'table = "audit.audit_logs"'
+          assert_includes annotation, 'schema = "audit"'
+
+          # Verify columns were extracted successfully
+          assert_includes annotation, 'columns = ['
+          assert_includes annotation, 'name = "id"'
+          assert_includes annotation, 'name = "table_name"'
+          assert_includes annotation, 'name = "record_id"'
+        end
+
+        def test_schema_search_path_handling
+          # Create test table in custom schema
+          @connection.execute('CREATE SCHEMA IF NOT EXISTS custom_schema')
+          @connection.execute(<<~SQL.squish)
+            CREATE TABLE IF NOT EXISTS custom_schema.widgets (
+              id serial PRIMARY KEY,
+              name varchar(100) NOT NULL
+            )
+          SQL
+
+          adapter = Postgresql.new(@connection, 'custom_schema.widgets')
+
+          # These operations should work without errors
+          assert_nothing_raised do
+            columns = adapter.send(:columns)
+
+            assert_predicate columns, :any?
+            assert(columns.any? { |c| c.name == 'id' })
+            assert(columns.any? { |c| c.name == 'name' })
+          end
+
+          # Verify primary_key extraction works
+          assert_nothing_raised do
+            pk = adapter.send(:primary_key_name)
+
+            assert_equal 'id', pk
+          end
+        ensure
+          begin
+            @connection.execute('DROP TABLE IF EXISTS custom_schema.widgets')
+          rescue
+            nil
+          end
+          begin
+            @connection.execute('DROP SCHEMA IF EXISTS custom_schema CASCADE')
+          rescue
+            nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes issue where rails_lens failed on PostgreSQL tables with schema prefixes (e.g., "cms.posts") with error: undefined method 'map' for an instance of String.

Changes:
- Add unqualified_table_name helper to extract table name without schema
- PostgreSQL adapter: Add with_schema_in_search_path for proper schema context
- Override connection methods (columns, indexes, foreign_keys, etc.) to use schema context
- Fix index columns handling to support both string and array formats with Array()
- Add comprehensive tests using existing AuditLog model (audit.audit_logs)
- Update CI matrix to test Rails 7.2, 8.0, and 8.1.beta1
- Conditional Rails version support in Gemfile (only when RAILS_VERSION env var is set)

Tested with:
- AuditLog model (audit.audit_logs) - existing namespaced model
- Columns, indexes, foreign keys, check constraints extraction
- Schema search_path manipulation and cleanup